### PR TITLE
add `RAYLIB_` prefix to colors

### DIFF
--- a/src/raylib.h
+++ b/src/raylib.h
@@ -172,33 +172,33 @@
 
 // Some Basic Colors
 // NOTE: Custom raylib color palette for amazing visuals on WHITE background
-#define LIGHTGRAY  CLITERAL(Color){ 200, 200, 200, 255 }   // Light Gray
-#define GRAY       CLITERAL(Color){ 130, 130, 130, 255 }   // Gray
-#define DARKGRAY   CLITERAL(Color){ 80, 80, 80, 255 }      // Dark Gray
-#define YELLOW     CLITERAL(Color){ 253, 249, 0, 255 }     // Yellow
-#define GOLD       CLITERAL(Color){ 255, 203, 0, 255 }     // Gold
-#define ORANGE     CLITERAL(Color){ 255, 161, 0, 255 }     // Orange
-#define PINK       CLITERAL(Color){ 255, 109, 194, 255 }   // Pink
-#define RED        CLITERAL(Color){ 230, 41, 55, 255 }     // Red
-#define MAROON     CLITERAL(Color){ 190, 33, 55, 255 }     // Maroon
-#define GREEN      CLITERAL(Color){ 0, 228, 48, 255 }      // Green
-#define LIME       CLITERAL(Color){ 0, 158, 47, 255 }      // Lime
-#define DARKGREEN  CLITERAL(Color){ 0, 117, 44, 255 }      // Dark Green
-#define SKYBLUE    CLITERAL(Color){ 102, 191, 255, 255 }   // Sky Blue
-#define BLUE       CLITERAL(Color){ 0, 121, 241, 255 }     // Blue
-#define DARKBLUE   CLITERAL(Color){ 0, 82, 172, 255 }      // Dark Blue
-#define PURPLE     CLITERAL(Color){ 200, 122, 255, 255 }   // Purple
-#define VIOLET     CLITERAL(Color){ 135, 60, 190, 255 }    // Violet
-#define DARKPURPLE CLITERAL(Color){ 112, 31, 126, 255 }    // Dark Purple
-#define BEIGE      CLITERAL(Color){ 211, 176, 131, 255 }   // Beige
-#define BROWN      CLITERAL(Color){ 127, 106, 79, 255 }    // Brown
-#define DARKBROWN  CLITERAL(Color){ 76, 63, 47, 255 }      // Dark Brown
+#define RAYLIB_LIGHTGRAY  CLITERAL(Color){ 200, 200, 200, 255 }   // Light Gray
+#define RAYLIB_GRAY       CLITERAL(Color){ 130, 130, 130, 255 }   // Gray
+#define RAYLIB_DARKGRAY   CLITERAL(Color){ 80, 80, 80, 255 }      // Dark Gray
+#define RAYLIB_YELLOW     CLITERAL(Color){ 253, 249, 0, 255 }     // Yellow
+#define RAYLIB_GOLD       CLITERAL(Color){ 255, 203, 0, 255 }     // Gold
+#define RAYLIB_ORANGE     CLITERAL(Color){ 255, 161, 0, 255 }     // Orange
+#define RAYLIB_PINK       CLITERAL(Color){ 255, 109, 194, 255 }   // Pink
+#define RAYLIB_RED        CLITERAL(Color){ 230, 41, 55, 255 }     // Red
+#define RAYLIB_MAROON     CLITERAL(Color){ 190, 33, 55, 255 }     // Maroon
+#define RAYLIB_GREEN      CLITERAL(Color){ 0, 228, 48, 255 }      // Green
+#define RAYLIB_LIME       CLITERAL(Color){ 0, 158, 47, 255 }      // Lime
+#define RAYLIB_DARKGREEN  CLITERAL(Color){ 0, 117, 44, 255 }      // Dark Green
+#define RAYLIB_SKYBLUE    CLITERAL(Color){ 102, 191, 255, 255 }   // Sky Blue
+#define RAYLIB_BLUE       CLITERAL(Color){ 0, 121, 241, 255 }     // Blue
+#define RAYLIB_DARKBLUE   CLITERAL(Color){ 0, 82, 172, 255 }      // Dark Blue
+#define RAYLIB_PURPLE     CLITERAL(Color){ 200, 122, 255, 255 }   // Purple
+#define RAYLIB_VIOLET     CLITERAL(Color){ 135, 60, 190, 255 }    // Violet
+#define RAYLIB_DARKPURPLE CLITERAL(Color){ 112, 31, 126, 255 }    // Dark Purple
+#define RAYLIB_BEIGE      CLITERAL(Color){ 211, 176, 131, 255 }   // Beige
+#define RAYLIB_BROWN      CLITERAL(Color){ 127, 106, 79, 255 }    // Brown
+#define RAYLIB_DARKBROWN  CLITERAL(Color){ 76, 63, 47, 255 }      // Dark Brown
 
-#define WHITE      CLITERAL(Color){ 255, 255, 255, 255 }   // White
-#define BLACK      CLITERAL(Color){ 0, 0, 0, 255 }         // Black
-#define BLANK      CLITERAL(Color){ 0, 0, 0, 0 }           // Blank (Transparent)
-#define MAGENTA    CLITERAL(Color){ 255, 0, 255, 255 }     // Magenta
-#define RAYWHITE   CLITERAL(Color){ 245, 245, 245, 255 }   // My own White (raylib logo)
+#define RAYLIB_WHITE      CLITERAL(Color){ 255, 255, 255, 255 }   // White
+#define RAYLIB_BLACK      CLITERAL(Color){ 0, 0, 0, 255 }         // Black
+#define RAYLIB_BLANK      CLITERAL(Color){ 0, 0, 0, 0 }           // Blank (Transparent)
+#define RAYLIB_MAGENTA    CLITERAL(Color){ 255, 0, 255, 255 }     // Magenta
+#define RAYLIB_RAYWHITE   CLITERAL(Color){ 245, 245, 245, 255 }   // My own White (raylib logo)
 
 //----------------------------------------------------------------------------------
 // Structures Definition


### PR DESCRIPTION
This is necessary since when I was attempting to use hw.h in initial setup PR I ran into errors where they both had defined COLORS with the same name. spinner still works and is just to resolve the duplicate naming between hw.h and raylib.h

PR that address the necessary changes for spinner can be found here https://github.com/commaai/openpilot/pull/34153