### PR TITLE
Don't poll for input events in EndDrawing

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -959,7 +959,9 @@ void EndDrawing(void)
         CORE.Time.frame += waitTime;    // Total frame time: update + draw + wait
     }
 
-//    PollInputEvents();      // Poll user events (before next frame update)
+#if !defined(PLATFORM_COMMA)
+    PollInputEvents();      // Poll user events (before next frame update)
+#endif  // PLATFORM_COMMA
 #endif
 
 #if defined(SUPPORT_SCREEN_CAPTURE)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -959,7 +959,7 @@ void EndDrawing(void)
         CORE.Time.frame += waitTime;    // Total frame time: update + draw + wait
     }
 
-    PollInputEvents();      // Poll user events (before next frame update)
+//    PollInputEvents();      // Poll user events (before next frame update)
 #endif
 
 #if defined(SUPPORT_SCREEN_CAPTURE)


### PR DESCRIPTION
So we can use a thread in Python to get all the touch events without dropping any. We can also get the touch events slightly earlier just before we start rendering for lower latency