### PR TITLE
add PLATFORM_OFFSCREEN: EGL surfaceless backend for headless CI

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -135,6 +135,12 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
         PLATFORM_OS = LINUX
     endif
 endif
+ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
+    UNAMEOS = $(shell uname)
+    ifeq ($(UNAMEOS),Linux)
+        PLATFORM_OS = LINUX
+    endif
+endif
 
 # RAYLIB_PATH adjustment for LINUX platform
 # TODO: Do we really need this?
@@ -282,6 +288,10 @@ endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
     INCLUDE_PATHS += -I$(RAYLIB_INCLUDE_PATH)
     INCLUDE_PATHS += -I/usr/include/libdrm
+endif
+
+ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
+    INCLUDE_PATHS += -I$(RAYLIB_INCLUDE_PATH)
 endif
 
 # Include GLFW required for examples/others/rlgl_standalone.c
@@ -474,6 +484,9 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
     # Libraries for DRM compiling
     # NOTE: Required packages: libasound2-dev (ALSA)
     LDLIBS = -lraylib -lGLESv2 -lEGL -lpthread -lrt -lm -lgbm -ldrm -ldl -latomic
+endif
+ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
+    LDLIBS = -lraylib -lGLESv2 -lEGL -lwayland-client -lwayland-egl -lpthread -lrt -lm -lGL -ldl -latomic
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_WEB)
     # Libraries for web (HTML5) compiling
@@ -702,6 +715,10 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_GLFW)
     endif
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
+	find . -type f -executable -delete
+	rm -fv *.o
+endif
+ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
 	find . -type f -executable -delete
 	rm -fv *.o
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -172,6 +172,15 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
         PLATFORM_SHELL = sh
     endif
 endif
+ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
+    UNAMEOS = $(shell uname)
+    ifeq ($(UNAMEOS),Linux)
+        PLATFORM_OS = LINUX
+    endif
+    ifndef PLATFORM_SHELL
+        PLATFORM_SHELL = sh
+    endif
+endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_WEB)
     ifeq ($(PLATFORM_OS),LINUX)
         ifndef PLATFORM_SHELL
@@ -252,6 +261,9 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_RGFW)
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
     # On DRM OpenGL ES 2.0 must be used
+    GRAPHICS = GRAPHICS_API_OPENGL_ES2
+endif
+ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
     GRAPHICS = GRAPHICS_API_OPENGL_ES2
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_WEB)
@@ -424,6 +436,9 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
     # without EGL_NO_X11 eglplatform.h tears Xlib.h in which tears X.h in
     # which contains a conflicting type Font
     CFLAGS += -DEGL_NO_X11
+    CFLAGS += -Werror=implicit-function-declaration
+endif
+ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
     CFLAGS += -Werror=implicit-function-declaration
 endif
 # Use Wayland display on Linux desktop
@@ -616,6 +631,12 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_RGFW)
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
     LDLIBS = -lGLESv2 -lEGL -ldrm -lgbm -lpthread -lrt -lm -ldl
+    ifeq ($(RAYLIB_MODULE_AUDIO),TRUE)
+        LDLIBS += -latomic
+    endif
+endif
+ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
+    LDLIBS = -lGLESv2 -lEGL -lGL -lpthread -lrt -lm -ldl
     ifeq ($(RAYLIB_MODULE_AUDIO),TRUE)
         LDLIBS += -latomic
     endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -368,6 +368,9 @@ ifeq ($(RAYLIB_BUILD_MODE),RELEASE)
     ifeq ($(TARGET_PLATFORM),PLATFORM_ANDROID)
         CFLAGS += -O2
     endif
+    ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
+        CFLAGS += -O2
+    endif
 endif
 
 # Additional flags for compiler (if desired)

--- a/src/Makefile
+++ b/src/Makefile
@@ -489,6 +489,9 @@ endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_DESKTOP_SDL)
     INCLUDE_PATHS += -I$(SDL_INCLUDE_PATH)
 endif
+ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
+    INCLUDE_PATHS += -I/usr/include/libdrm
+endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_WEB)
     INCLUDE_PATHS += -Iexternal/glfw/include
 endif
@@ -636,7 +639,7 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
     endif
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
-    LDLIBS = -lGLESv2 -lEGL -lGL -lpthread -lrt -lm -ldl
+    LDLIBS = -lGLESv2 -lEGL -lGL -lpthread -lrt -lm -ldl -lgbm -ldrm
     ifeq ($(RAYLIB_MODULE_AUDIO),TRUE)
         LDLIBS += -latomic
     endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -181,6 +181,15 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
         PLATFORM_SHELL = sh
     endif
 endif
+ifeq ($(TARGET_PLATFORM),PLATFORM_OFFSCREEN)
+    UNAMEOS = $(shell uname)
+    ifeq ($(UNAMEOS),Linux)
+        PLATFORM_OS = LINUX
+    endif
+    ifndef PLATFORM_SHELL
+        PLATFORM_SHELL = sh
+    endif
+endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_WEB)
     ifeq ($(PLATFORM_OS),LINUX)
         ifndef PLATFORM_SHELL
@@ -265,6 +274,9 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
     GRAPHICS = GRAPHICS_API_OPENGL_ES2
+endif
+ifeq ($(TARGET_PLATFORM),PLATFORM_OFFSCREEN)
+    GRAPHICS ?= GRAPHICS_API_OPENGL_33
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_WEB)
     # On HTML5 OpenGL ES 2.0 is used, emscripten translates it to WebGL 1.0
@@ -371,6 +383,9 @@ ifeq ($(RAYLIB_BUILD_MODE),RELEASE)
     ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
         CFLAGS += -O2
     endif
+    ifeq ($(TARGET_PLATFORM),PLATFORM_OFFSCREEN)
+        CFLAGS += -O1
+    endif
 endif
 
 # Additional flags for compiler (if desired)
@@ -442,6 +457,10 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_DRM)
     CFLAGS += -Werror=implicit-function-declaration
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
+    CFLAGS += -Werror=implicit-function-declaration
+endif
+ifeq ($(TARGET_PLATFORM),PLATFORM_OFFSCREEN)
+    CFLAGS += -DEGL_NO_X11
     CFLAGS += -Werror=implicit-function-declaration
 endif
 # Use Wayland display on Linux desktop
@@ -646,6 +665,9 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
     ifeq ($(RAYLIB_MODULE_AUDIO),TRUE)
         LDLIBS += -latomic
     endif
+endif
+ifeq ($(TARGET_PLATFORM),PLATFORM_OFFSCREEN)
+    LDLIBS = -lEGL -lGL -lpthread -lrt -lm -ldl
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_ANDROID)
     LDLIBS = -llog -landroid -lEGL -lGLESv2 -lOpenSLES -lc -lm

--- a/src/Makefile
+++ b/src/Makefile
@@ -460,7 +460,6 @@ ifeq ($(TARGET_PLATFORM),PLATFORM_COMMA)
     CFLAGS += -Werror=implicit-function-declaration
 endif
 ifeq ($(TARGET_PLATFORM),PLATFORM_OFFSCREEN)
-    CFLAGS += -DEGL_NO_X11
     CFLAGS += -Werror=implicit-function-declaration
 endif
 # Use Wayland display on Linux desktop

--- a/src/platforms/rcore_comma.c
+++ b/src/platforms/rcore_comma.c
@@ -1,0 +1,594 @@
+/**********************************************************************************************
+*
+*   rcore_<platform> template - Functions to manage window, graphics device and inputs
+*
+*   PLATFORM: <PLATFORM>
+*       - TODO: Define the target platform for the core
+*
+*   LIMITATIONS:
+*       - Limitation 01
+*       - Limitation 02
+*
+*   POSSIBLE IMPROVEMENTS:
+*       - Improvement 01
+*       - Improvement 02
+*
+*   ADDITIONAL NOTES:
+*       - TRACELOG() function is located in raylib [utils] module
+*
+*   CONFIGURATION:
+*       #define RCORE_PLATFORM_CUSTOM_FLAG
+*           Custom flag for rcore on target platform -not used-
+*
+*   DEPENDENCIES:
+*       - <platform-specific SDK dependency>
+*       - gestures: Gestures system for touch-ready devices (or simulated from mouse inputs)
+*
+*
+*   LICENSE: zlib/libpng
+*
+*   Copyright (c) 2013-2024 Ramon Santamaria (@raysan5) and contributors
+*
+*   This software is provided "as-is", without any express or implied warranty. In no event
+*   will the authors be held liable for any damages arising from the use of this software.
+*
+*   Permission is granted to anyone to use this software for any purpose, including commercial
+*   applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*     1. The origin of this software must not be misrepresented; you must not claim that you
+*     wrote the original software. If you use this software in a product, an acknowledgment
+*     in the product documentation would be appreciated but is not required.
+*
+*     2. Altered source versions must be plainly marked as such, and must not be misrepresented
+*     as being the original software.
+*
+*     3. This notice may not be removed or altered from any source distribution.
+*
+**********************************************************************************************/
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <wayland-client.h>
+#include <wayland-server.h>
+#include <wayland-client-protocol.h>
+#include <wayland-egl.h> // must be included before the EGL headers
+
+#include <EGL/egl.h>
+#include <EGL/eglplatform.h>
+
+#include <GLES2/gl2.h>
+
+//----------------------------------------------------------------------------------
+// Types and Structures Definition
+//----------------------------------------------------------------------------------
+
+// hold all the low level wayland stuff
+struct wayland_platform {
+  struct wl_compositor *wl_compositor;
+  struct wl_surface *wl_surface;
+  struct wl_egl_window *wl_egl_window;
+  struct wl_region *wl_region;
+  struct wl_shell *wl_shell;
+  struct wl_shell_surface *wl_shell_surface;
+  struct wl_display *wl_display;
+  struct wl_registry *wl_registry;
+};
+
+// hold all the low level egl stuff
+struct egl_platform {
+  EGLDisplay display;
+  EGLSurface surface;
+  EGLContext context;
+  EGLConfig config;
+
+  EGLNativeDisplayType native_display;
+  EGLNativeWindowType native_window;
+
+  int native_window_width;
+  int native_window_height;
+};
+
+typedef struct {
+    struct wayland_platform wayland;
+    struct egl_platform egl;
+} PlatformData;
+
+//----------------------------------------------------------------------------------
+// Global Variables Definition
+//----------------------------------------------------------------------------------
+extern CoreData CORE;                   // Global CORE state context
+
+static PlatformData platform = { 0 };   // Platform specific data
+
+//----------------------------------------------------------------------------------
+// comma specific code
+//----------------------------------------------------------------------------------
+
+#define CASE_STR( value ) case value: return #value;
+const char *eglGetErrorString(EGLint error) {
+    switch(error) {
+      CASE_STR( EGL_SUCCESS             )
+      CASE_STR( EGL_NOT_INITIALIZED     )
+      CASE_STR( EGL_BAD_ACCESS          )
+      CASE_STR( EGL_BAD_ALLOC           )
+      CASE_STR( EGL_BAD_ATTRIBUTE       )
+      CASE_STR( EGL_BAD_CONTEXT         )
+      CASE_STR( EGL_BAD_CONFIG          )
+      CASE_STR( EGL_BAD_CURRENT_SURFACE )
+      CASE_STR( EGL_BAD_DISPLAY         )
+      CASE_STR( EGL_BAD_SURFACE         )
+      CASE_STR( EGL_BAD_MATCH           )
+      CASE_STR( EGL_BAD_PARAMETER       )
+      CASE_STR( EGL_BAD_NATIVE_PIXMAP   )
+      CASE_STR( EGL_BAD_NATIVE_WINDOW   )
+      CASE_STR( EGL_CONTEXT_LOST        )
+      default: return "Unknown";
+    }
+}
+#undef CASE_STR
+
+void wl_shell_surface_handle_ping (void *data, struct wl_shell_surface *shell_surface, uint32_t serial) {
+  wl_shell_surface_pong(shell_surface, serial);
+}
+
+void wl_shell_surface_handle_configure (void *data, struct wl_shell_surface *shell_surface, uint32_t edges, int32_t width, int32_t height) {
+  wl_egl_window_resize(platform.egl.native_window, width, height, 0, 0);
+}
+
+void wl_shell_surface_handle_popup_done(void *data, struct wl_shell_surface *shell_surface) {
+}
+
+static struct wl_shell_surface_listener wl_shell_surface_listener = {
+  .ping = &wl_shell_surface_handle_ping,
+  .configure = &wl_shell_surface_handle_configure,
+  .popup_done = &wl_shell_surface_handle_popup_done
+};
+
+static void wl_registry_handle_global (void *data, struct wl_registry *registry, uint32_t id, const char *interface, uint32_t version) {
+  if (!strcmp(interface, "wl_compositor")) {
+    // Need version 3 of wl_compositor in order to do the rotation transform with wl_surface_set_buffer_transform
+    platform.wayland.wl_compositor = wl_registry_bind(registry, id, &wl_compositor_interface, 3);
+  } else if (!strcmp(interface, "wl_shell")) {
+    platform.wayland.wl_shell = wl_registry_bind(registry, id, &wl_shell_interface, 1);
+  }
+}
+
+static void wl_registry_handle_global_remove (void *data, struct wl_registry *registry, uint32_t id) {
+}
+
+const struct wl_registry_listener wl_registry_listener = {
+  .global = wl_registry_handle_global,
+  .global_remove = wl_registry_handle_global_remove
+};
+
+static int init_wayland(int width, int height) {
+  platform.wayland.wl_display = wl_display_connect(NULL);
+  if (platform.wayland.wl_display == NULL) {
+    TRACELOG(LOG_WARNING, "COMMA: Failed to create a Wayland display. Failed with: %s", strerror(errno));
+    return -1;
+  }
+
+  platform.wayland.wl_compositor = NULL;
+  platform.wayland.wl_shell = NULL;
+
+  platform.wayland.wl_registry = wl_display_get_registry(platform.wayland.wl_display);
+  wl_registry_add_listener(platform.wayland.wl_registry, &wl_registry_listener, NULL);
+
+  wl_display_dispatch(platform.wayland.wl_display);
+  wl_display_roundtrip(platform.wayland.wl_display);
+
+  if (platform.wayland.wl_compositor == NULL || platform.wayland.wl_compositor == NULL) {
+    TRACELOG(LOG_WARNING, "COMMA: Failed to bind Wayland globals");
+    return -1;
+  }
+
+  // create a surface with a buffer to do render on it
+  platform.wayland.wl_surface = wl_compositor_create_surface(platform.wayland.wl_compositor);
+
+  // apply rotation transform to the buffer of the surface
+  wl_surface_set_buffer_transform(platform.wayland.wl_surface, WL_OUTPUT_TRANSFORM_270);
+
+  platform.wayland.wl_shell_surface = wl_shell_get_shell_surface(platform.wayland.wl_shell, platform.wayland.wl_surface);
+  wl_shell_surface_add_listener(platform.wayland.wl_shell_surface, &wl_shell_surface_listener, NULL);
+  wl_shell_surface_set_toplevel(platform.wayland.wl_shell_surface);
+
+  platform.wayland.wl_region = wl_compositor_create_region(platform.wayland.wl_compositor);
+  wl_region_add(platform.wayland.wl_region, 0, 0, width, height);
+  wl_surface_set_opaque_region(platform.wayland.wl_surface, platform.wayland.wl_region);
+
+  // the native window for egl is a our wl_surface
+  platform.egl.native_window = wl_egl_window_create(platform.wayland.wl_surface, width, height);
+  if (platform.egl.native_window == NULL) {
+    TRACELOG(LOG_WARNING, "COMMA: Failed to create a Wayland EGL window");
+    return -1;
+  }
+  // the native display for egl is a our wl_display
+  platform.egl.native_display = platform.wayland.wl_display;
+  platform.egl.native_window_width = width;
+  platform.egl.native_window_height = height;
+
+  return 0;
+}
+
+static int init_egl () {
+   EGLint major;
+   EGLint minor;
+   EGLConfig config;
+   EGLint num_config;
+   EGLint frame_buffer_config [] = {
+     EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+     EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+     EGL_RED_SIZE,   8,
+     EGL_GREEN_SIZE, 8,
+     EGL_BLUE_SIZE,  8,
+     EGL_DEPTH_SIZE, 24,
+     EGL_NONE
+   };
+   // ask for an OpenGL ES 2 rendering context
+   EGLint context_config [] = { EGL_CONTEXT_MAJOR_VERSION, 2, EGL_NONE, EGL_NONE };
+
+   // get an egl display with our native display (in our case, a wl_display)
+   platform.egl.display = eglGetDisplay(platform.egl.native_display);
+   if (platform.egl.display == EGL_NO_DISPLAY) {
+     TRACELOG(LOG_WARNING, "COMMA: Failed to get an EGL display");
+     return -1;
+   }
+
+   if (!eglInitialize(platform.egl.display, &major, &minor)) {
+     TRACELOG(LOG_WARNING, "COMMA: Failed to initialize the EGL display. Error code: %s", eglGetErrorString(eglGetError()));
+     return -1;
+   }
+   TRACELOG(LOG_INFO, "COMMA: Using EGL version %i.%i", major, minor);
+
+   if (!eglChooseConfig(platform.egl.display, frame_buffer_config, &config, 1, &num_config)) {
+     TRACELOG(LOG_WARNING, "COMMA: Failed to get a valid EGL display config. Error code: %s", eglGetErrorString(eglGetError()));
+     return -1;
+   }
+   TRACELOG(LOG_INFO, "COMMA: Found %i valid EGL display configs", num_config);
+
+   platform.egl.surface = eglCreateWindowSurface(platform.egl.display, config, platform.egl.native_window, NULL);
+   if (platform.egl.surface == EGL_NO_SURFACE) {
+     TRACELOG(LOG_WARNING, "COMMA: Failed to create an EGL surface. Error code: %s", eglGetErrorString(eglGetError()));
+     return -1;
+   }
+
+   platform.egl.context = eglCreateContext(platform.egl.display, config, EGL_NO_CONTEXT, context_config);
+   if (platform.egl.context == EGL_NO_CONTEXT) {
+     TRACELOG(LOG_WARNING, "COMMA: Failed to create an OpenGL ES context. Error code: %s", eglGetErrorString(eglGetError()));
+     return -1;
+   }
+
+   if (!eglMakeCurrent(platform.egl.display, platform.egl.surface, platform.egl.surface, platform.egl.context)) {
+     TRACELOG(LOG_WARNING, "COMMA: Failed to attach the OpenGL ES context to the EGL surface. Error code: %s", eglGetErrorString(eglGetError()));
+     return -1;
+   }
+
+   // enable depth testing. Not necessary if only doing 2D
+   glEnable(GL_DEPTH_TEST);
+
+   return 0;
+}
+
+
+//----------------------------------------------------------------------------------
+// Module Internal Functions Declaration
+//----------------------------------------------------------------------------------
+int InitPlatform(void);          // Initialize platform (graphics, inputs and more)
+bool InitGraphicsDevice(void);   // Initialize graphics device
+
+//----------------------------------------------------------------------------------
+// Module Functions Declaration
+//----------------------------------------------------------------------------------
+// NOTE: Functions declaration is provided by raylib.h
+
+//----------------------------------------------------------------------------------
+// Module Functions Definition: Window and Graphics Device
+//----------------------------------------------------------------------------------
+
+// Check if application should close
+bool WindowShouldClose(void) {
+  return false;
+}
+
+// Toggle fullscreen mode
+void ToggleFullscreen(void) {
+  TRACELOG(LOG_WARNING, "ToggleFullscreen() not available on target platform");
+}
+
+// Toggle borderless windowed mode
+void ToggleBorderlessWindowed(void) {
+  TRACELOG(LOG_WARNING, "ToggleBorderlessWindowed() not available on target platform");
+}
+
+// Set window state: maximized, if resizable
+void MaximizeWindow(void) {
+  TRACELOG(LOG_WARNING, "MaximizeWindow() not available on target platform");
+}
+
+// Set window state: minimized
+void MinimizeWindow(void) {
+  TRACELOG(LOG_WARNING, "MinimizeWindow() not available on target platform");
+}
+
+// Set window state: not minimized/maximized
+void RestoreWindow(void) {
+  TRACELOG(LOG_WARNING, "RestoreWindow() not available on target platform");
+}
+
+// Set window configuration state using flags
+void SetWindowState(unsigned int flags) {
+  TRACELOG(LOG_WARNING, "SetWindowState() not available on target platform");
+}
+
+// Clear window configuration state flags
+void ClearWindowState(unsigned int flags) {
+  TRACELOG(LOG_WARNING, "ClearWindowState() not available on target platform");
+}
+
+// Set icon for window
+void SetWindowIcon(Image image) {
+  TRACELOG(LOG_WARNING, "SetWindowIcon() not available on target platform");
+}
+
+// Set icon for window
+void SetWindowIcons(Image *images, int count) {
+  TRACELOG(LOG_WARNING, "SetWindowIcons() not available on target platform");
+}
+
+// Set title for window
+void SetWindowTitle(const char *title) {
+  CORE.Window.title = title;
+}
+
+// Set window position on screen (windowed mode)
+void SetWindowPosition(int x, int y) {
+  TRACELOG(LOG_WARNING, "SetWindowPosition() not available on target platform");
+}
+
+// Set monitor for the current window
+void SetWindowMonitor(int monitor) {
+  TRACELOG(LOG_WARNING, "SetWindowMonitor() not available on target platform");
+}
+
+// Set window minimum dimensions (FLAG_WINDOW_RESIZABLE)
+void SetWindowMinSize(int width, int height) {
+  CORE.Window.screenMin.width = width;
+  CORE.Window.screenMin.height = height;
+}
+
+// Set window maximum dimensions (FLAG_WINDOW_RESIZABLE)
+void SetWindowMaxSize(int width, int height) {
+  CORE.Window.screenMax.width = width;
+  CORE.Window.screenMax.height = height;
+}
+
+// Set window dimensions
+void SetWindowSize(int width, int height) {
+  TRACELOG(LOG_WARNING, "SetWindowSize() not available on target platform");
+}
+
+// Set window opacity, value opacity is between 0.0 and 1.0
+void SetWindowOpacity(float opacity) {
+  TRACELOG(LOG_WARNING, "SetWindowOpacity() not available on target platform");
+}
+
+// Set window focused
+void SetWindowFocused(void) {
+  TRACELOG(LOG_WARNING, "SetWindowFocused() not available on target platform");
+}
+
+// Get native window handle
+void *GetWindowHandle(void) {
+  TRACELOG(LOG_WARNING, "GetWindowHandle() not implemented on target platform");
+  return NULL;
+}
+
+// Get number of monitors
+int GetMonitorCount(void) {
+  TRACELOG(LOG_WARNING, "GetMonitorCount() not implemented on target platform");
+  return 1;
+}
+
+// Get number of monitors
+int GetCurrentMonitor(void) {
+  TRACELOG(LOG_WARNING, "GetCurrentMonitor() not implemented on target platform");
+  return 0;
+}
+
+// Get selected monitor position
+Vector2 GetMonitorPosition(int monitor) {
+  TRACELOG(LOG_WARNING, "GetMonitorPosition() not implemented on target platform");
+  return (Vector2){ 0, 0 };
+}
+
+// Get selected monitor width (currently used by monitor)
+int GetMonitorWidth(int monitor) {
+  TRACELOG(LOG_WARNING, "GetMonitorWidth() not implemented on target platform");
+  return 0;
+}
+
+// Get selected monitor height (currently used by monitor)
+int GetMonitorHeight(int monitor) {
+  TRACELOG(LOG_WARNING, "GetMonitorHeight() not implemented on target platform");
+  return 0;
+}
+
+// Get selected monitor physical width in millimetres
+int GetMonitorPhysicalWidth(int monitor) {
+  TRACELOG(LOG_WARNING, "GetMonitorPhysicalWidth() not implemented on target platform");
+  return 0;
+}
+
+// Get selected monitor physical height in millimetres
+int GetMonitorPhysicalHeight(int monitor) {
+  TRACELOG(LOG_WARNING, "GetMonitorPhysicalHeight() not implemented on target platform");
+  return 0;
+}
+
+// Get selected monitor refresh rate
+int GetMonitorRefreshRate(int monitor) {
+  TRACELOG(LOG_WARNING, "GetMonitorRefreshRate() not implemented on target platform");
+  return 0;
+}
+
+// Get the human-readable, UTF-8 encoded name of the selected monitor
+const char *GetMonitorName(int monitor) {
+  TRACELOG(LOG_WARNING, "GetMonitorName() not implemented on target platform");
+  return "";
+}
+
+// Get window position XY on monitor
+Vector2 GetWindowPosition(void) {
+  TRACELOG(LOG_WARNING, "GetWindowPosition() not implemented on target platform");
+  return (Vector2){ 0, 0 };
+}
+
+// Get window scale DPI factor for current monitor
+Vector2 GetWindowScaleDPI(void) {
+  TRACELOG(LOG_WARNING, "GetWindowScaleDPI() not implemented on target platform");
+  return (Vector2){ 1.0f, 1.0f };
+}
+
+// Set clipboard text content
+void SetClipboardText(const char *text) {
+  TRACELOG(LOG_WARNING, "SetClipboardText() not implemented on target platform");
+}
+
+// Get clipboard text content
+// NOTE: returned string is allocated and freed by GLFW
+const char *GetClipboardText(void) {
+  TRACELOG(LOG_WARNING, "GetClipboardText() not implemented on target platform");
+  return NULL;
+}
+
+// Get clipboard image
+Image GetClipboardImage(void) {
+  Image image = { 0 };
+  TRACELOG(LOG_WARNING, "GetClipboardImage() not implemented on target platform");
+  return image;
+}
+
+// Show mouse cursor
+void ShowCursor(void) {
+  CORE.Input.Mouse.cursorHidden = false;
+}
+
+// Hides mouse cursor
+void HideCursor(void) {
+  CORE.Input.Mouse.cursorHidden = true;
+}
+
+// Enables cursor (unlock cursor)
+void EnableCursor(void) {
+  // Set cursor position in the middle
+  SetMousePosition(CORE.Window.screen.width/2, CORE.Window.screen.height/2);
+
+  CORE.Input.Mouse.cursorHidden = false;
+}
+
+// Disables cursor (lock cursor)
+void DisableCursor(void) {
+  // Set cursor position in the middle
+  SetMousePosition(CORE.Window.screen.width/2, CORE.Window.screen.height/2);
+
+  CORE.Input.Mouse.cursorHidden = true;
+}
+
+// Swap back buffer with front buffer (screen drawing)
+void SwapScreenBuffer(void) {
+  eglSwapBuffers(platform.egl.display, platform.egl.surface);
+}
+
+//----------------------------------------------------------------------------------
+// Module Functions Definition: Misc
+//----------------------------------------------------------------------------------
+
+// Get elapsed time measure in seconds since InitTimer()
+double GetTime(void) {
+  double time = 0.0;
+  struct timespec ts = { 0 };
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  unsigned long long int nanoSeconds = (unsigned long long int)ts.tv_sec*1000000000LLU + (unsigned long long int)ts.tv_nsec;
+
+  time = (double)(nanoSeconds - CORE.Time.base)*1e-9;  // Elapsed time since InitTimer()
+
+  return time;
+}
+
+void OpenURL(const char *url) {
+  TRACELOG(LOG_WARNING, "OpenURL() not implemented on target platform");
+}
+
+//----------------------------------------------------------------------------------
+// Module Functions Definition: Inputs
+//----------------------------------------------------------------------------------
+
+// Set internal gamepad mappings
+int SetGamepadMappings(const char *mappings) {
+  TRACELOG(LOG_WARNING, "SetGamepadMappings() not implemented on target platform");
+  return 0;
+}
+
+// Set mouse position XY
+void SetMousePosition(int x, int y) {
+  CORE.Input.Mouse.currentPosition = (Vector2){ (float)x, (float)y };
+  CORE.Input.Mouse.previousPosition = CORE.Input.Mouse.currentPosition;
+}
+
+// Set mouse cursor
+void SetMouseCursor(int cursor) {
+  TRACELOG(LOG_WARNING, "SetMouseCursor() not implemented on target platform");
+}
+
+// Get physical key name.
+const char *GetKeyName(int key) {
+  TRACELOG(LOG_WARNING, "GetKeyName() not implemented on target platform");
+  return "";
+}
+
+// Register all input events
+void PollInputEvents(void) {
+}
+
+//----------------------------------------------------------------------------------
+// Module Internal Functions Definition
+//----------------------------------------------------------------------------------
+
+int InitPlatform(void) {
+
+  // only support fullscreen
+  CORE.Window.fullscreen = true;
+  CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
+
+  // in our case, all those width/height are the same
+  CORE.Window.currentFbo.width = CORE.Window.screen.width;
+  CORE.Window.currentFbo.height = CORE.Window.screen.height;
+  CORE.Window.display.width = CORE.Window.screen.width;
+  CORE.Window.display.height = CORE.Window.screen.height;
+  CORE.Window.render.width = CORE.Window.screen.width;
+  CORE.Window.render.height = CORE.Window.screen.height;
+
+  if (init_wayland(CORE.Window.currentFbo.width, CORE.Window.currentFbo.height)) {
+    TRACELOG(LOG_FATAL, "COMMA: Failed to initialize Wayland");
+    return -1;
+  }
+
+  if (init_egl()) {
+    TRACELOG(LOG_FATAL, "COMMA: Failed to initialize EGL");
+    return -1;
+  }
+
+  SetupFramebuffer(CORE.Window.display.width, CORE.Window.display.height);
+  rlLoadExtensions(eglGetProcAddress);
+  InitTimer();
+  CORE.Storage.basePath = GetWorkingDirectory();
+
+  TRACELOG(LOG_INFO, "COMMA: Initialized successfully");
+  return 0;
+}
+
+void ClosePlatform(void) {
+}

--- a/src/platforms/rcore_comma.c
+++ b/src/platforms/rcore_comma.c
@@ -589,9 +589,8 @@ const char *GetKeyName(int key) {
   return "";
 }
 
-// Register all input events
 void PollInputEvents(void) {
-  // represents to which finger an event belongs
+  // slot i is for events of finger i
   static int slot = 0;
 
   // must be called every frames
@@ -612,32 +611,32 @@ void PollInputEvents(void) {
         // detect new touch on screen
         platform.touch.fingers[slot].gesture_action = platform.touch.fingers[slot].gesture_action == TOUCH_ACTION_UP ? TOUCH_ACTION_DOWN : TOUCH_ACTION_MOVE;
 
-        CORE.Input.Touch.position[0].x = platform.touch.fingers[0].x;
-        CORE.Input.Touch.position[0].y = platform.touch.fingers[0].y;
-        CORE.Input.Touch.currentTouchState[0] = 1;
+        CORE.Input.Touch.position[slot].x = platform.touch.fingers[slot].x;
+        CORE.Input.Touch.position[slot].y = platform.touch.fingers[slot].y;
+        CORE.Input.Touch.currentTouchState[slot] = 1;
         // map touch state on mouse for conveniance
-        CORE.Input.Mouse.currentPosition.x = platform.touch.fingers[0].x;
-        CORE.Input.Mouse.currentPosition.y = platform.touch.fingers[0].y;
-        CORE.Input.Mouse.currentButtonState[0] = 1;
+        CORE.Input.Mouse.currentPosition.x = platform.touch.fingers[slot].x;
+        CORE.Input.Mouse.currentPosition.y = platform.touch.fingers[slot].y;
+        CORE.Input.Mouse.currentButtonState[slot] = 1;
 
       } else if (platform.touch.fingers[slot].action == TOUCH_ACTION_UP) {
         // finger off the screen
-        platform.touch.fingers[0].gesture_action = TOUCH_ACTION_UP;
+        platform.touch.fingers[slot].gesture_action = TOUCH_ACTION_UP;
 
-        CORE.Input.Touch.position[0].x = -1;
-        CORE.Input.Touch.position[0].y = -1;
-        CORE.Input.Touch.currentTouchState[0] = 0;
-        CORE.Input.Mouse.currentButtonState[0] = 0;
-        CORE.Input.Touch.previousTouchState[0] = 1;
-        CORE.Input.Mouse.previousButtonState[0] = 1;
+        CORE.Input.Touch.position[slot].x = -1;
+        CORE.Input.Touch.position[slot].y = -1;
+        CORE.Input.Touch.currentTouchState[slot] = 0;
+        CORE.Input.Mouse.currentButtonState[slot] = 0;
+        CORE.Input.Touch.previousTouchState[slot] = 1;
+        CORE.Input.Mouse.previousButtonState[slot] = 1;
       }
 
       // interpret gestures (scroll, pinch, drag, ...)
       GestureEvent gestureEvent = {0};
-      gestureEvent.touchAction = platform.touch.fingers[0].gesture_action;
+      gestureEvent.touchAction = platform.touch.fingers[slot].gesture_action;
       gestureEvent.pointCount = CORE.Input.Touch.pointCount;
-      gestureEvent.pointId[0] = 0;
-      gestureEvent.position[0] = CORE.Input.Touch.position[0];
+      gestureEvent.pointId[slot] = slot;
+      gestureEvent.position[slot] = CORE.Input.Touch.position[slot];
       ProcessGestureEvent(gestureEvent);
     }
 

--- a/src/platforms/rcore_comma.c
+++ b/src/platforms/rcore_comma.c
@@ -653,9 +653,9 @@ void PollInputEvents(void) {
         if (event.code == ABS_MT_TRACKING_ID) {
           platform.touch.fingers[slot].action = event.value == -1 ? TOUCH_ACTION_UP : TOUCH_ACTION_DOWN;
         } else if (event.code == ABS_MT_POSITION_X) {
-          platform.touch.fingers[slot].y = CORE.Window.screen.height - event.value;
+          platform.touch.fingers[slot].y = event.value;
         } else if (event.code == ABS_MT_POSITION_Y) {
-          platform.touch.fingers[slot].x = event.value;
+          platform.touch.fingers[slot].x = CORE.Window.screen.width - event.value;
         }
       }
     }

--- a/src/platforms/rcore_comma.c
+++ b/src/platforms/rcore_comma.c
@@ -572,6 +572,10 @@ int SetGamepadMappings(const char *mappings) {
   return 0;
 }
 
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration) {
+  TRACELOG(LOG_WARNING, "GamepadSetVibration() not implemented on target platform");
+}
+
 // Set mouse position XY
 void SetMousePosition(int x, int y) {
   CORE.Input.Mouse.currentPosition = (Vector2){ (float)x, (float)y };

--- a/src/platforms/rcore_comma.c
+++ b/src/platforms/rcore_comma.c
@@ -908,7 +908,7 @@ void SwapScreenBuffer(void) {
   }
 
   if (drmModePageFlip(platform.drm.fd, platform.drm.crtc_id, platform.gbm.next_fb, 0, NULL) != 0) {
-    TRACELOG(LOG_WARNING, "COMMA: ");
+    TRACELOG(LOG_WARNING, "COMMA: Failed to page flip");
     drmModeRmFB(platform.drm.fd, platform.gbm.next_fb);
     gbm_surface_release_buffer(platform.gbm.surface, platform.gbm.next_bo);
     platform.gbm.next_bo = NULL;

--- a/src/platforms/rcore_comma.c
+++ b/src/platforms/rcore_comma.c
@@ -306,8 +306,7 @@ static int init_egl () {
    }
 
    // >1 is not supported
-   EGLBoolean ok = eglSwapInterval(platform.egl.display, (CORE.Window.flags & FLAG_VSYNC_HINT) ? 1 : 0);
-   if (ok == EGL_FALSE) {
+   if (!eglSwapInterval(platform.egl.display, (CORE.Window.flags & FLAG_VSYNC_HINT) ? 1 : 0)) {
      TRACELOG(LOG_WARNING, "COMMA: eglSwapInterval failed. Error code: %s", eglGetErrorString(eglGetError()));
      return -1;
    }

--- a/src/platforms/rcore_comma.c
+++ b/src/platforms/rcore_comma.c
@@ -554,29 +554,50 @@ static int get_or_create_fb_for_bo(struct gbm_bo *bo, uint32_t *out_fb) {
     return 0;
 }
 
+static FILE* open_with_retry(const char *path, const char *mode) {
+  const int sleep_ms = 50;
+  int waited = 0;
+  FILE *f = NULL;
+
+  while (waited <= 500) {
+    f = fopen(path, mode);
+    if (f) {
+      return f;
+    }
+    struct timespec ts = { .tv_sec = 0, .tv_nsec = sleep_ms * 1000000L };
+    nanosleep(&ts, NULL);
+    waited += sleep_ms;
+  }
+
+  return NULL;
+}
+
 static int turn_screen_on () {
-  FILE *f = fopen("/sys/class/backlight/panel0-backlight/bl_power", "w");
+  FILE *f = open_with_retry("/sys/class/backlight/panel0-backlight/bl_power", "w");
   if (f) {
     fputs("0", f);
     fclose(f);
   } else {
+    TRACELOG(LOG_WARNING, "COMMA: Failed to open bl_power");
     return -1;
   }
 
   unsigned long max_brightness = 0;
-  f = fopen("/sys/class/backlight/panel0-backlight/max_brightness", "r");
+  f = open_with_retry("/sys/class/backlight/panel0-backlight/max_brightness", "r");
   if (f) {
     fscanf(f, "%lu", &max_brightness);
     fclose(f);
   } else {
+    TRACELOG(LOG_WARNING, "COMMA: Failed to open max_brightness");
     return -1;
   }
 
-  f = fopen("/sys/class/backlight/panel0-backlight/brightness", "w");
+  f = open_with_retry("/sys/class/backlight/panel0-backlight/brightness", "w");
   if (f) {
     fprintf(f, "%lu", max_brightness);
     fclose(f);
   } else {
+    TRACELOG(LOG_WARNING, "COMMA: Failed to open brightness");
     return -1;
   }
 

--- a/src/platforms/rcore_comma.c
+++ b/src/platforms/rcore_comma.c
@@ -1123,25 +1123,8 @@ void ClosePlatform(void) {
     platform.egl.display = EGL_NO_DISPLAY;
   }
 
-  if (platform.gbm.current_fb) {
-    drmModeRmFB(platform.drm.fd, platform.gbm.current_fb);
-  }
-
-  if (platform.gbm.next_fb) {
-    drmModeRmFB(platform.drm.fd, platform.gbm.next_fb);
-  }
-
-  if (platform.gbm.surface) {
-    if (platform.gbm.current_bo) {
-      gbm_surface_release_buffer(platform.gbm.surface, platform.gbm.current_bo);
-    }
-
-    if (platform.gbm.next_bo) {
-      gbm_surface_release_buffer(platform.gbm.surface, platform.gbm.next_bo);
-    }
-
-    gbm_surface_destroy(platform.gbm.surface);
-    platform.gbm.surface = NULL;
+  if (platform.gbm.surface && platform.gbm.next_bo) {
+    gbm_surface_release_buffer(platform.gbm.surface, platform.gbm.next_bo);
   }
 
   if (platform.gbm.device) {

--- a/src/platforms/rcore_comma.c
+++ b/src/platforms/rcore_comma.c
@@ -640,7 +640,7 @@ static int init_touch(const char *dev_path) {
     }
   } else {
     TRACELOG(LOG_WARNING, "COMMA: Failed to open screen origin");
-    return -1;
+    platform.canonical_zero = false;
   }
 
   for (int i = 0; i < MAX_TOUCH_POINTS; ++i) {

--- a/src/platforms/rcore_comma.c
+++ b/src/platforms/rcore_comma.c
@@ -1106,6 +1106,8 @@ int InitPlatform(void) {
 }
 
 void ClosePlatform(void) {
+  CORE.Window.ready = false;
+
   if (platform.egl.display != EGL_NO_DISPLAY) {
     eglMakeCurrent(platform.egl.display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 

--- a/src/platforms/rcore_comma.c
+++ b/src/platforms/rcore_comma.c
@@ -599,6 +599,7 @@ static int turn_screen_on () {
 
   f = open_with_retry("/sys/class/backlight/panel0-backlight/brightness", "w");
   if (f) {
+    max_brightness = (int)((max_brightness / 100.0 ) * 65.0);
     fprintf(f, "%lu", max_brightness);
     fclose(f);
   } else {

--- a/src/platforms/rcore_comma.c
+++ b/src/platforms/rcore_comma.c
@@ -276,6 +276,10 @@ static int init_color_correction(void) {
   char *shader = NULL;
   struct color_correction_values *ccv = NULL;
 
+  if (platform.canonical_zero) {
+    return 0;
+  }
+
   shader = malloc(1024);
   if(shader == NULL){
     TRACELOG(LOG_WARNING, "COMMA: Failed to malloc color correction");

--- a/src/platforms/rcore_comma.c
+++ b/src/platforms/rcore_comma.c
@@ -289,6 +289,13 @@ static int init_egl () {
      return -1;
    }
 
+   // >1 is not supported
+   EGLBoolean ok = eglSwapInterval(platform.egl.display, (CORE.Window.flags & FLAG_VSYNC_HINT) ? 1 : 0);
+   if (ok == EGL_FALSE) {
+     TRACELOG(LOG_WARNING, "COMMA: eglSwapInterval failed. Error code: %s", eglGetErrorString(eglGetError()));
+     return -1;
+   }
+
    // enable depth testing. Not necessary if only doing 2D
    glEnable(GL_DEPTH_TEST);
 

--- a/src/platforms/rcore_comma.c
+++ b/src/platforms/rcore_comma.c
@@ -666,9 +666,6 @@ void PollInputEvents(void) {
           }
 
         } else if (platform.touch.fingers[i].state == FINGER_STATE_REMOVING) {
-          CORE.Input.Touch.position[i].x = -1;
-          CORE.Input.Touch.position[i].y = -1;
-
           // if we received a touch down and up event in the same frame,
           // delay up event by one frame so that API user needs no special handling
           if (CORE.Input.Touch.previousTouchState[i] == 0) {

--- a/src/platforms/rcore_offscreen.c
+++ b/src/platforms/rcore_offscreen.c
@@ -1,0 +1,491 @@
+/**********************************************************************************************
+*
+*   rcore_offscreen - Functions to manage window, graphics device and inputs
+*
+*   PLATFORM: OFFSCREEN
+*       - EGL surfaceless platform for headless/CI rendering without a display server
+*       - Uses EGL_MESA_platform_surfaceless + Mesa llvmpipe for software OpenGL
+*       - No X11, Wayland, DRM, or GPU required
+*
+*   DEPENDENCIES:
+*       - EGL (libEGL)
+*       - OpenGL (libGL) or OpenGL ES (libGLESv2)
+*
+*   LICENSE: zlib/libpng
+*
+*   Copyright (c) 2013-2024 Ramon Santamaria (@raysan5) and contributors
+*
+*   This software is provided "as-is", without any express or implied warranty. In no event
+*   will the authors be held liable for any damages arising from the use of this software.
+*
+*   Permission is granted to anyone to use this software for any purpose, including commercial
+*   applications, and to alter it and redistribute it freely, subject to the following restrictions:
+*
+*     1. The origin of this software must not be misrepresented; you must not claim that you
+*     wrote the original software. If you use this software in a product, an acknowledgment
+*     in the product documentation would be appreciated but is not required.
+*
+*     2. Altered source versions must be plainly marked as such, and must not be misrepresented
+*     as being the original software.
+*
+*     3. This notice may not be removed or altered from any source distribution.
+*
+**********************************************************************************************/
+
+#include <string.h>
+#include <time.h>
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+
+#ifndef EGL_PLATFORM_SURFACELESS_MESA
+#define EGL_PLATFORM_SURFACELESS_MESA 0x31DD
+#endif
+
+//----------------------------------------------------------------------------------
+// Types and Structures Definition
+//----------------------------------------------------------------------------------
+typedef struct {
+    EGLDisplay display;
+    EGLSurface surface;
+    EGLContext context;
+} PlatformData;
+
+//----------------------------------------------------------------------------------
+// Global Variables Definition
+//----------------------------------------------------------------------------------
+extern CoreData CORE;                   // Global CORE state context
+
+static PlatformData platform = { 0 };   // Platform specific data
+
+//----------------------------------------------------------------------------------
+// Local helpers
+//----------------------------------------------------------------------------------
+
+#define CASE_STR(value) case value: return #value;
+static const char *eglGetErrorString(EGLint error) {
+    switch (error) {
+        CASE_STR(EGL_SUCCESS)
+        CASE_STR(EGL_NOT_INITIALIZED)
+        CASE_STR(EGL_BAD_ACCESS)
+        CASE_STR(EGL_BAD_ALLOC)
+        CASE_STR(EGL_BAD_ATTRIBUTE)
+        CASE_STR(EGL_BAD_CONTEXT)
+        CASE_STR(EGL_BAD_CONFIG)
+        CASE_STR(EGL_BAD_CURRENT_SURFACE)
+        CASE_STR(EGL_BAD_DISPLAY)
+        CASE_STR(EGL_BAD_SURFACE)
+        CASE_STR(EGL_BAD_MATCH)
+        CASE_STR(EGL_BAD_PARAMETER)
+        CASE_STR(EGL_BAD_NATIVE_PIXMAP)
+        CASE_STR(EGL_BAD_NATIVE_WINDOW)
+        CASE_STR(EGL_CONTEXT_LOST)
+        default: return "Unknown";
+    }
+}
+#undef CASE_STR
+
+static int hasExtension(const char *extensions, const char *ext) {
+    if (!extensions || !ext) return 0;
+    size_t len = strlen(ext);
+    const char *p = extensions;
+    while ((p = strstr(p, ext)) != NULL) {
+        if ((p == extensions || p[-1] == ' ') && (p[len] == '\0' || p[len] == ' ')) return 1;
+        p += len;
+    }
+    return 0;
+}
+
+//----------------------------------------------------------------------------------
+// Module Internal Functions Declaration
+//----------------------------------------------------------------------------------
+int InitPlatform(void);
+bool InitGraphicsDevice(void);
+
+//----------------------------------------------------------------------------------
+// Module Functions Definition: Window and Graphics Device
+//----------------------------------------------------------------------------------
+
+bool WindowShouldClose(void) {
+    if (CORE.Window.ready) return CORE.Window.shouldClose;
+    else return true;
+}
+
+void ToggleFullscreen(void) {
+    TRACELOG(LOG_WARNING, "ToggleFullscreen() not available on target platform");
+}
+
+void ToggleBorderlessWindowed(void) {
+    TRACELOG(LOG_WARNING, "ToggleBorderlessWindowed() not available on target platform");
+}
+
+void MaximizeWindow(void) {
+    TRACELOG(LOG_WARNING, "MaximizeWindow() not available on target platform");
+}
+
+void MinimizeWindow(void) {
+    TRACELOG(LOG_WARNING, "MinimizeWindow() not available on target platform");
+}
+
+void RestoreWindow(void) {
+    TRACELOG(LOG_WARNING, "RestoreWindow() not available on target platform");
+}
+
+void SetWindowState(unsigned int flags) {
+    TRACELOG(LOG_WARNING, "SetWindowState() not available on target platform");
+}
+
+void ClearWindowState(unsigned int flags) {
+    TRACELOG(LOG_WARNING, "ClearWindowState() not available on target platform");
+}
+
+void SetWindowIcon(Image image) {
+    TRACELOG(LOG_WARNING, "SetWindowIcon() not available on target platform");
+}
+
+void SetWindowIcons(Image *images, int count) {
+    TRACELOG(LOG_WARNING, "SetWindowIcons() not available on target platform");
+}
+
+void SetWindowTitle(const char *title) {
+    CORE.Window.title = title;
+}
+
+void SetWindowPosition(int x, int y) {
+    TRACELOG(LOG_WARNING, "SetWindowPosition() not available on target platform");
+}
+
+void SetWindowMonitor(int monitor) {
+    TRACELOG(LOG_WARNING, "SetWindowMonitor() not available on target platform");
+}
+
+void SetWindowMinSize(int width, int height) {
+    CORE.Window.screenMin.width = width;
+    CORE.Window.screenMin.height = height;
+}
+
+void SetWindowMaxSize(int width, int height) {
+    CORE.Window.screenMax.width = width;
+    CORE.Window.screenMax.height = height;
+}
+
+void SetWindowSize(int width, int height) {
+    TRACELOG(LOG_WARNING, "SetWindowSize() not available on target platform");
+}
+
+void SetWindowOpacity(float opacity) {
+    TRACELOG(LOG_WARNING, "SetWindowOpacity() not available on target platform");
+}
+
+void SetWindowFocused(void) {
+    TRACELOG(LOG_WARNING, "SetWindowFocused() not available on target platform");
+}
+
+void *GetWindowHandle(void) {
+    return NULL;
+}
+
+int GetMonitorCount(void) {
+    return 1;
+}
+
+int GetCurrentMonitor(void) {
+    return 0;
+}
+
+Vector2 GetMonitorPosition(int monitor) {
+    return (Vector2){ 0, 0 };
+}
+
+int GetMonitorWidth(int monitor) {
+    return CORE.Window.screen.width;
+}
+
+int GetMonitorHeight(int monitor) {
+    return CORE.Window.screen.height;
+}
+
+int GetMonitorPhysicalWidth(int monitor) {
+    return 0;
+}
+
+int GetMonitorPhysicalHeight(int monitor) {
+    return 0;
+}
+
+int GetMonitorRefreshRate(int monitor) {
+    return 60;
+}
+
+const char *GetMonitorName(int monitor) {
+    return "Offscreen (EGL surfaceless)";
+}
+
+Vector2 GetWindowPosition(void) {
+    return (Vector2){ 0, 0 };
+}
+
+Vector2 GetWindowScaleDPI(void) {
+    return (Vector2){ 1.0f, 1.0f };
+}
+
+void SetClipboardText(const char *text) {
+    TRACELOG(LOG_WARNING, "SetClipboardText() not implemented on target platform");
+}
+
+const char *GetClipboardText(void) {
+    return NULL;
+}
+
+Image GetClipboardImage(void) {
+    Image image = { 0 };
+    return image;
+}
+
+void ShowCursor(void) {
+    CORE.Input.Mouse.cursorHidden = false;
+}
+
+void HideCursor(void) {
+    CORE.Input.Mouse.cursorHidden = true;
+}
+
+void EnableCursor(void) {
+    SetMousePosition(CORE.Window.screen.width/2, CORE.Window.screen.height/2);
+    CORE.Input.Mouse.cursorHidden = false;
+}
+
+void DisableCursor(void) {
+    SetMousePosition(CORE.Window.screen.width/2, CORE.Window.screen.height/2);
+    CORE.Input.Mouse.cursorHidden = true;
+}
+
+// Swap back buffer with front buffer (screen drawing)
+void SwapScreenBuffer(void) {
+    if (platform.surface != EGL_NO_SURFACE) {
+        eglSwapBuffers(platform.display, platform.surface);
+    }
+}
+
+//----------------------------------------------------------------------------------
+// Module Functions Definition: Misc
+//----------------------------------------------------------------------------------
+
+double GetTime(void) {
+    double time = 0.0;
+    struct timespec ts = { 0 };
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    unsigned long long int nanoSeconds = (unsigned long long int)ts.tv_sec*1000000000LLU + (unsigned long long int)ts.tv_nsec;
+    time = (double)(nanoSeconds - CORE.Time.base)*1e-9;
+    return time;
+}
+
+void OpenURL(const char *url) {
+    TRACELOG(LOG_WARNING, "OpenURL() not implemented on target platform");
+}
+
+//----------------------------------------------------------------------------------
+// Module Functions Definition: Inputs
+//----------------------------------------------------------------------------------
+
+int SetGamepadMappings(const char *mappings) {
+    return 0;
+}
+
+void SetGamepadVibration(int gamepad, float leftMotor, float rightMotor, float duration) {
+}
+
+void SetMousePosition(int x, int y) {
+    CORE.Input.Mouse.currentPosition = (Vector2){ (float)x, (float)y };
+    CORE.Input.Mouse.previousPosition = CORE.Input.Mouse.currentPosition;
+}
+
+void SetMouseCursor(int cursor) {
+}
+
+const char *GetKeyName(int key) {
+    return "";
+}
+
+void PollInputEvents(void) {
+#if defined(SUPPORT_GESTURES_SYSTEM)
+    UpdateGestures();
+#endif
+
+    CORE.Input.Keyboard.keyPressedQueueCount = 0;
+    CORE.Input.Keyboard.charPressedQueueCount = 0;
+    for (int i = 0; i < MAX_KEYBOARD_KEYS; i++) CORE.Input.Keyboard.keyRepeatInFrame[i] = 0;
+    CORE.Input.Gamepad.lastButtonPressed = 0;
+    for (int i = 0; i < MAX_TOUCH_POINTS; i++) CORE.Input.Touch.previousTouchState[i] = CORE.Input.Touch.currentTouchState[i];
+    for (int i = 0; i < 260; i++) {
+        CORE.Input.Keyboard.previousKeyState[i] = CORE.Input.Keyboard.currentKeyState[i];
+        CORE.Input.Keyboard.keyRepeatInFrame[i] = 0;
+    }
+}
+
+//----------------------------------------------------------------------------------
+// Module Internal Functions Definition
+//----------------------------------------------------------------------------------
+
+int InitPlatform(void) {
+    TRACELOG(LOG_INFO, "OFFSCREEN: Initializing EGL surfaceless platform");
+
+    // Check for surfaceless platform support in EGL client extensions
+    const char *clientExts = eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS);
+    if (!clientExts) {
+        TRACELOG(LOG_FATAL, "OFFSCREEN: Cannot query EGL client extensions (EGL too old?)");
+        return -1;
+    }
+
+    if (!hasExtension(clientExts, "EGL_MESA_platform_surfaceless")) {
+        TRACELOG(LOG_FATAL, "OFFSCREEN: EGL_MESA_platform_surfaceless not supported");
+        return -1;
+    }
+
+    // Get platform display function
+    PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT =
+        (PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress("eglGetPlatformDisplayEXT");
+    if (!eglGetPlatformDisplayEXT) {
+        TRACELOG(LOG_FATAL, "OFFSCREEN: Cannot resolve eglGetPlatformDisplayEXT");
+        return -1;
+    }
+
+    // Get EGL display via surfaceless platform (no X11/Wayland needed)
+    platform.display = eglGetPlatformDisplayEXT(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, NULL);
+    if (platform.display == EGL_NO_DISPLAY) {
+        TRACELOG(LOG_FATAL, "OFFSCREEN: eglGetPlatformDisplayEXT failed: %s", eglGetErrorString(eglGetError()));
+        return -1;
+    }
+
+    EGLint major, minor;
+    if (!eglInitialize(platform.display, &major, &minor)) {
+        TRACELOG(LOG_FATAL, "OFFSCREEN: eglInitialize failed: %s", eglGetErrorString(eglGetError()));
+        return -1;
+    }
+    TRACELOG(LOG_INFO, "OFFSCREEN: EGL %d.%d initialized", major, minor);
+
+    // Choose EGL config
+#if defined(GRAPHICS_API_OPENGL_ES2) || defined(GRAPHICS_API_OPENGL_ES3)
+    EGLint renderableType = EGL_OPENGL_ES2_BIT;
+#else
+    EGLint renderableType = EGL_OPENGL_BIT;
+#endif
+
+    const EGLint configAttribs[] = {
+        EGL_RENDERABLE_TYPE, renderableType,
+        EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+        EGL_RED_SIZE, 8,
+        EGL_GREEN_SIZE, 8,
+        EGL_BLUE_SIZE, 8,
+        EGL_ALPHA_SIZE, 8,
+        EGL_DEPTH_SIZE, 24,
+        EGL_STENCIL_SIZE, 8,
+        EGL_NONE
+    };
+
+    EGLConfig config;
+    EGLint numConfigs;
+    if (!eglChooseConfig(platform.display, configAttribs, &config, 1, &numConfigs) || numConfigs == 0) {
+        TRACELOG(LOG_FATAL, "OFFSCREEN: eglChooseConfig failed: %s", eglGetErrorString(eglGetError()));
+        eglTerminate(platform.display);
+        return -1;
+    }
+
+    // Bind API
+#if defined(GRAPHICS_API_OPENGL_ES2) || defined(GRAPHICS_API_OPENGL_ES3)
+    eglBindAPI(EGL_OPENGL_ES_API);
+#else
+    eglBindAPI(EGL_OPENGL_API);
+#endif
+
+    // Create context
+#if defined(GRAPHICS_API_OPENGL_ES2)
+    const EGLint contextAttribs[] = { EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE };
+#elif defined(GRAPHICS_API_OPENGL_ES3)
+    const EGLint contextAttribs[] = { EGL_CONTEXT_CLIENT_VERSION, 3, EGL_NONE };
+#elif defined(GRAPHICS_API_OPENGL_43)
+    const EGLint contextAttribs[] = {
+        EGL_CONTEXT_MAJOR_VERSION, 4,
+        EGL_CONTEXT_MINOR_VERSION, 3,
+        EGL_CONTEXT_OPENGL_PROFILE_MASK, EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT,
+        EGL_NONE
+    };
+#elif defined(GRAPHICS_API_OPENGL_33)
+    const EGLint contextAttribs[] = {
+        EGL_CONTEXT_MAJOR_VERSION, 3,
+        EGL_CONTEXT_MINOR_VERSION, 3,
+        EGL_CONTEXT_OPENGL_PROFILE_MASK, EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT,
+        EGL_NONE
+    };
+#elif defined(GRAPHICS_API_OPENGL_21)
+    const EGLint contextAttribs[] = {
+        EGL_CONTEXT_MAJOR_VERSION, 2,
+        EGL_CONTEXT_MINOR_VERSION, 1,
+        EGL_NONE
+    };
+#else
+    const EGLint contextAttribs[] = { EGL_NONE };
+#endif
+
+    platform.context = eglCreateContext(platform.display, config, EGL_NO_CONTEXT, contextAttribs);
+    if (platform.context == EGL_NO_CONTEXT) {
+        TRACELOG(LOG_FATAL, "OFFSCREEN: eglCreateContext failed: %s", eglGetErrorString(eglGetError()));
+        eglTerminate(platform.display);
+        return -1;
+    }
+
+    // Create a 1x1 pbuffer surface so FBO 0 is valid
+    const EGLint pbufferAttribs[] = { EGL_WIDTH, 1, EGL_HEIGHT, 1, EGL_NONE };
+    platform.surface = eglCreatePbufferSurface(platform.display, config, pbufferAttribs);
+    if (platform.surface == EGL_NO_SURFACE) {
+        TRACELOG(LOG_WARNING, "OFFSCREEN: pbuffer creation failed, trying surfaceless context");
+        platform.surface = EGL_NO_SURFACE;
+    }
+
+    if (!eglMakeCurrent(platform.display, platform.surface, platform.surface, platform.context)) {
+        TRACELOG(LOG_FATAL, "OFFSCREEN: eglMakeCurrent failed: %s", eglGetErrorString(eglGetError()));
+        eglDestroyContext(platform.display, platform.context);
+        eglTerminate(platform.display);
+        return -1;
+    }
+
+    eglSwapInterval(platform.display, 0);
+
+    // Set up window dimensions from InitWindow() params (already set in CORE.Window.screen by rcore.c)
+    CORE.Window.display.width = CORE.Window.screen.width;
+    CORE.Window.display.height = CORE.Window.screen.height;
+    CORE.Window.render.width = CORE.Window.screen.width;
+    CORE.Window.render.height = CORE.Window.screen.height;
+    CORE.Window.currentFbo.width = CORE.Window.screen.width;
+    CORE.Window.currentFbo.height = CORE.Window.screen.height;
+
+    SetupFramebuffer(CORE.Window.currentFbo.width, CORE.Window.currentFbo.height);
+    rlLoadExtensions(eglGetProcAddress);
+    InitTimer();
+    CORE.Storage.basePath = GetWorkingDirectory();
+
+    CORE.Window.ready = true;
+
+    TRACELOG(LOG_INFO, "OFFSCREEN: Platform initialized successfully (%ix%i)", CORE.Window.screen.width, CORE.Window.screen.height);
+    return 0;
+}
+
+void ClosePlatform(void) {
+    CORE.Window.ready = false;
+
+    if (platform.display != EGL_NO_DISPLAY) {
+        eglMakeCurrent(platform.display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+
+        if (platform.surface != EGL_NO_SURFACE) {
+            eglDestroySurface(platform.display, platform.surface);
+            platform.surface = EGL_NO_SURFACE;
+        }
+        if (platform.context != EGL_NO_CONTEXT) {
+            eglDestroyContext(platform.display, platform.context);
+            platform.context = EGL_NO_CONTEXT;
+        }
+
+        eglTerminate(platform.display);
+        platform.display = EGL_NO_DISPLAY;
+    }
+}

--- a/src/platforms/rcore_offscreen.c
+++ b/src/platforms/rcore_offscreen.c
@@ -35,6 +35,20 @@
 #include <string.h>
 #include <time.h>
 
+// GLAD (included by rlgl.h) embeds its own khrplatform.h which defines the
+// __khrplatform_h_ include guard but uses KHRONOS_GLAD_API_PTR instead of
+// KHRONOS_APIENTRY. When the system EGL headers later try to use
+// KHRONOS_APIENTRY (via eglplatform.h -> khrplatform.h, which is now skipped
+// due to the guard), the macro is undefined and all EGL function declarations
+// fail. Fix by defining the missing macros before including EGL headers.
+#ifndef KHRONOS_APIENTRY
+    #ifdef _WIN32
+        #define KHRONOS_APIENTRY __stdcall
+    #else
+        #define KHRONOS_APIENTRY
+    #endif
+#endif
+
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 

--- a/src/raylib.h
+++ b/src/raylib.h
@@ -172,33 +172,91 @@
 
 // Some Basic Colors
 // NOTE: Custom raylib color palette for amazing visuals on WHITE background
-#define LIGHTGRAY  CLITERAL(Color){ 200, 200, 200, 255 }   // Light Gray
-#define GRAY       CLITERAL(Color){ 130, 130, 130, 255 }   // Gray
-#define DARKGRAY   CLITERAL(Color){ 80, 80, 80, 255 }      // Dark Gray
-#define YELLOW     CLITERAL(Color){ 253, 249, 0, 255 }     // Yellow
-#define GOLD       CLITERAL(Color){ 255, 203, 0, 255 }     // Gold
-#define ORANGE     CLITERAL(Color){ 255, 161, 0, 255 }     // Orange
-#define PINK       CLITERAL(Color){ 255, 109, 194, 255 }   // Pink
-#define RED        CLITERAL(Color){ 230, 41, 55, 255 }     // Red
-#define MAROON     CLITERAL(Color){ 190, 33, 55, 255 }     // Maroon
-#define GREEN      CLITERAL(Color){ 0, 228, 48, 255 }      // Green
-#define LIME       CLITERAL(Color){ 0, 158, 47, 255 }      // Lime
-#define DARKGREEN  CLITERAL(Color){ 0, 117, 44, 255 }      // Dark Green
-#define SKYBLUE    CLITERAL(Color){ 102, 191, 255, 255 }   // Sky Blue
-#define BLUE       CLITERAL(Color){ 0, 121, 241, 255 }     // Blue
-#define DARKBLUE   CLITERAL(Color){ 0, 82, 172, 255 }      // Dark Blue
-#define PURPLE     CLITERAL(Color){ 200, 122, 255, 255 }   // Purple
-#define VIOLET     CLITERAL(Color){ 135, 60, 190, 255 }    // Violet
-#define DARKPURPLE CLITERAL(Color){ 112, 31, 126, 255 }    // Dark Purple
-#define BEIGE      CLITERAL(Color){ 211, 176, 131, 255 }   // Beige
-#define BROWN      CLITERAL(Color){ 127, 106, 79, 255 }    // Brown
-#define DARKBROWN  CLITERAL(Color){ 76, 63, 47, 255 }      // Dark Brown
+#define _rl_LIGHTGRAY  CLITERAL(Color){ 200, 200, 200, 255 }   // Light Gray
+#define _rl_GRAY       CLITERAL(Color){ 130, 130, 130, 255 }   // Gray
+#define _rl_DARKGRAY   CLITERAL(Color){ 80, 80, 80, 255 }      // Dark Gray
+#define _rl_YELLOW     CLITERAL(Color){ 253, 249, 0, 255 }     // Yellow
+#define _rl_GOLD       CLITERAL(Color){ 255, 203, 0, 255 }     // Gold
+#define _rl_ORANGE     CLITERAL(Color){ 255, 161, 0, 255 }     // Orange
+#define _rl_PINK       CLITERAL(Color){ 255, 109, 194, 255 }   // Pink
+#define _rl_RED        CLITERAL(Color){ 230, 41, 55, 255 }     // Red
+#define _rl_MAROON     CLITERAL(Color){ 190, 33, 55, 255 }     // Maroon
+#define _rl_GREEN      CLITERAL(Color){ 0, 228, 48, 255 }      // Green
+#define _rl_LIME       CLITERAL(Color){ 0, 158, 47, 255 }      // Lime
+#define _rl_DARKGREEN  CLITERAL(Color){ 0, 117, 44, 255 }      // Dark Green
+#define _rl_SKYBLUE    CLITERAL(Color){ 102, 191, 255, 255 }   // Sky Blue
+#define _rl_BLUE       CLITERAL(Color){ 0, 121, 241, 255 }     // Blue
+#define _rl_DARKBLUE   CLITERAL(Color){ 0, 82, 172, 255 }      // Dark Blue
+#define _rl_PURPLE     CLITERAL(Color){ 200, 122, 255, 255 }   // Purple
+#define _rl_VIOLET     CLITERAL(Color){ 135, 60, 190, 255 }    // Violet
+#define _rl_DARKPURPLE CLITERAL(Color){ 112, 31, 126, 255 }    // Dark Purple
+#define _rl_BEIGE      CLITERAL(Color){ 211, 176, 131, 255 }   // Beige
+#define _rl_BROWN      CLITERAL(Color){ 127, 106, 79, 255 }    // Brown
+#define _rl_DARKBROWN  CLITERAL(Color){ 76, 63, 47, 255 }      // Dark Brown
 
-#define WHITE      CLITERAL(Color){ 255, 255, 255, 255 }   // White
-#define BLACK      CLITERAL(Color){ 0, 0, 0, 255 }         // Black
-#define BLANK      CLITERAL(Color){ 0, 0, 0, 0 }           // Blank (Transparent)
-#define MAGENTA    CLITERAL(Color){ 255, 0, 255, 255 }     // Magenta
-#define RAYWHITE   CLITERAL(Color){ 245, 245, 245, 255 }   // My own White (raylib logo)
+#define _rl_WHITE      CLITERAL(Color){ 255, 255, 255, 255 }   // White
+#define _rl_BLACK      CLITERAL(Color){ 0, 0, 0, 255 }         // Black
+#define _rl_BLANK      CLITERAL(Color){ 0, 0, 0, 0 }           // Blank (Transparent)
+#define _rl_MAGENTA    CLITERAL(Color){ 255, 0, 255, 255 }     // Magenta
+#define _rl_RAYWHITE   CLITERAL(Color){ 245, 245, 245, 255 }   // My own White (raylib logo)
+
+#ifndef OPENPILOT_RAYLIB
+  #define LIGHTGRAY  _rl_LIGHTGRAY
+  #define GRAY       _rl_GRAY
+  #define DARKGRAY   _rl_DARKGRAY
+  #define YELLOW     _rl_YELLOW
+  #define GOLD       _rl_GOLD
+  #define ORANGE     _rl_ORANGE
+  #define PINK       _rl_PINK
+  #define RED        _rl_RED
+  #define MAROON     _rl_MAROON
+  #define GREEN      _rl_GREEN
+  #define LIME       _rl_LIME
+  #define DARKGREEN  _rl_DARKGREEN
+  #define SKYBLUE    _rl_SKYBLUE
+  #define BLUE       _rl_BLUE
+  #define DARKBLUE   _rl_DARKBLUE
+  #define PURPLE     _rl_PURPLE
+  #define VIOLET     _rl_VIOLET
+  #define DARKPURPLE _rl_DARKBLUE
+  #define BEIGE      _rl_BEIGE
+  #define BROWN      _rl_BROWN
+  #define DARKBROWN  _rl_DARKBROWN
+
+  #define WHITE      _rl_WHITE
+  #define BLACK      _rl_BLACK
+  #define BLANK      _rl_BLANK
+  #define MAGENTA    _rl_MAGENTA
+  #define RAYWHITE   _rl_RAYWHITE
+#else
+  #define RAYLIB_LIGHTGRAY  _rl_LIGHTGRAY
+  #define RAYLIB_GRAY       _rl_GRAY
+  #define RAYLIB_DARKGRAY   _rl_DARKGRAY
+  #define RAYLIB_YELLOW     _rl_YELLOW
+  #define RAYLIB_GOLD       _rl_GOLD
+  #define RAYLIB_ORANGE     _rl_ORANGE
+  #define RAYLIB_PINK       _rl_PINK
+  #define RAYLIB_RED        _rl_RED
+  #define RAYLIB_MAROON     _rl_MAROON
+  #define RAYLIB_GREEN      _rl_GREEN
+  #define RAYLIB_LIME       _rl_LIME
+  #define RAYLIB_DARKGREEN  _rl_DARKGREEN
+  #define RAYLIB_SKYBLUE    _rl_SKYBLUE
+  #define RAYLIB_BLUE       _rl_BLUE
+  #define RAYLIB_DARKBLUE   _rl_DARKBLUE
+  #define RAYLIB_PURPLE     _rl_PURPLE
+  #define RAYLIB_VIOLET     _rl_VIOLET
+  #define RAYLIB_DARKPURPLE _rl_DARKBLUE
+  #define RAYLIB_BEIGE      _rl_BEIGE
+  #define RAYLIB_BROWN      _rl_BROWN
+  #define RAYLIB_DARKBROWN  _rl_DARKBROWN
+
+  #define RAYLIB_WHITE      _rl_WHITE
+  #define RAYLIB_BLACK      _rl_BLACK
+  #define RAYLIB_BLANK      _rl_BLANK
+  #define RAYLIB_MAGENTA    _rl_MAGENTA
+  #define RAYLIB_RAYWHITE   _rl_RAYWHITE
+#endif
 
 //----------------------------------------------------------------------------------
 // Structures Definition

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -548,6 +548,8 @@ const char *TextFormat(const char *text, ...);              // Formatting of tex
     #include "platforms/rcore_drm.c"
 #elif defined(PLATFORM_ANDROID)
     #include "platforms/rcore_android.c"
+#elif defined(PLATFORM_COMMA)
+    #include "platforms/rcore_comma.c"
 #else
     // TODO: Include your custom platform backend!
     // i.e software rendering backend or console backend!
@@ -617,6 +619,8 @@ void InitWindow(int width, int height, const char *title)
     TRACELOG(LOG_INFO, "Platform backend: NATIVE DRM");
 #elif defined(PLATFORM_ANDROID)
     TRACELOG(LOG_INFO, "Platform backend: ANDROID");
+#elif defined(PLATFORM_COMMA)
+    TRACELOG(LOG_INFO, "Platform backend: COMMA");
 #else
     // TODO: Include your custom platform backend!
     // i.e software rendering backend or console backend!

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -959,7 +959,9 @@ void EndDrawing(void)
         CORE.Time.frame += waitTime;    // Total frame time: update + draw + wait
     }
 
+#if !defined(PLATFORM_COMMA)
     PollInputEvents();      // Poll user events (before next frame update)
+#endif  // PLATFORM_COMMA
 #endif
 
 #if defined(SUPPORT_SCREEN_CAPTURE)

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -559,6 +559,8 @@ const char *TextFormat(const char *text, ...);              // Formatting of tex
     #include "platforms/rcore_android.c"
 #elif defined(PLATFORM_COMMA)
     #include "platforms/rcore_comma.c"
+#elif defined(PLATFORM_OFFSCREEN)
+    #include "platforms/rcore_offscreen.c"
 #else
     // TODO: Include your custom platform backend!
     // i.e software rendering backend or console backend!
@@ -630,6 +632,8 @@ void InitWindow(int width, int height, const char *title)
     TRACELOG(LOG_INFO, "Platform backend: ANDROID");
 #elif defined(PLATFORM_COMMA)
     TRACELOG(LOG_INFO, "Platform backend: COMMA");
+#elif defined(PLATFORM_OFFSCREEN)
+    TRACELOG(LOG_INFO, "Platform backend: OFFSCREEN (EGL surfaceless)");
 #else
     // TODO: Include your custom platform backend!
     // i.e software rendering backend or console backend!
@@ -985,9 +989,9 @@ void EndDrawing(void)
         CORE.Time.frame += waitTime;    // Total frame time: update + draw + wait
     }
 
-#if !defined(PLATFORM_COMMA)
+#if !defined(PLATFORM_COMMA) && !defined(PLATFORM_OFFSCREEN)
     PollInputEvents();      // Poll user events (before next frame update)
-#endif  // PLATFORM_COMMA
+#endif  // PLATFORM_COMMA || PLATFORM_OFFSCREEN
 #endif
 
 #if defined(SUPPORT_SCREEN_CAPTURE)


### PR DESCRIPTION
## Summary
- Adds `PLATFORM_OFFSCREEN` platform backend using `EGL_MESA_platform_surfaceless`
- Creates an OpenGL context without any display server (no X11/Wayland/Xvfb needed)
- Uses a 1x1 pbuffer surface so FBO 0 remains valid
- Supports OpenGL 3.3 (desktop) and OpenGL ES 2/3 via build flags
- All window/input functions are stubbed appropriately for headless use

## Motivation
Allows openpilot CI to run UI tests and generate UI reports without Xvfb. Combined with Mesa's llvmpipe, this provides full software OpenGL rendering in containers with no GPU or display server.

## Test plan
- [ ] Build with `make PLATFORM=PLATFORM_OFFSCREEN` on Linux
- [ ] Verify raylib examples render correctly to FBOs
- [ ] Run openpilot UI tests without Xvfb

🤖 Generated with [Claude Code](https://claude.com/claude-code)