### PR TITLE
fix: initialize rotation rects to fix desktop rendering

### DIFF
--- a/src/rcore.c
+++ b/src/rcore.c
@@ -676,8 +676,7 @@ void InitWindow(int width, int height, const char *title)
     CORE.Window.screenScale = MatrixIdentity();     // No draw scaling required by default
     if ((title != NULL) && (title[0] != 0)) CORE.Window.title = title;
 
-    // Initialize default identity rotation rects (full copy, no rotation)
-    // Comma platform overrides these in InitPlatform() for device-specific rotation
+    // Initialize default rotation rects
     CORE.Window.rotation_source = (Rectangle){ 0.0f, 0.0f, (float)CORE.Window.screen.width, -(float)CORE.Window.screen.height };
     CORE.Window.rotation_destination = (Rectangle){ 0.0f, 0.0f, (float)CORE.Window.screen.width, (float)CORE.Window.screen.height };
 

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -736,6 +736,14 @@ void InitWindow(int width, int height, const char *title)
 
     CORE.Window.rotated_fb = LoadRenderTexture(CORE.Window.screen.width, CORE.Window.screen.height);
 
+    // Initialize default (identity) rotation params for non-comma platforms.
+    // rcore_comma.c's InitPlatform() sets rotation_destination.width > 0 for device rotation,
+    // so this guard prevents overwriting those values.
+    if (CORE.Window.rotation_destination.width == 0.0f) {
+        CORE.Window.rotation_source = (Rectangle){ 0.0f, 0.0f, (float)CORE.Window.screen.width, -(float)CORE.Window.screen.height };
+        CORE.Window.rotation_destination = (Rectangle){ 0.0f, 0.0f, (float)CORE.Window.screen.width, (float)CORE.Window.screen.height };
+    }
+
     CORE.Window.color_correction_shader = LoadShaderFromMemory(NULL, CORE.Window.color_correction_shader_src);
     if (!IsShaderValid(CORE.Window.color_correction_shader)) {
       TraceLog(LOG_ERROR, "COMMA: Failed to build color correction shader");

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -773,6 +773,10 @@ void CloseWindow(void)
     ClosePlatform();
     //--------------------------------------------------------------
 
+    // Reset rotation state to prevent poisoning from temp windows
+    CORE.Window.rotation_source = (Rectangle){0};
+    CORE.Window.rotation_destination = (Rectangle){0};
+
     CORE.Window.ready = false;
     TRACELOG(LOG_INFO, "Window closed successfully");
 }

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -676,6 +676,11 @@ void InitWindow(int width, int height, const char *title)
     CORE.Window.screenScale = MatrixIdentity();     // No draw scaling required by default
     if ((title != NULL) && (title[0] != 0)) CORE.Window.title = title;
 
+    // Initialize default identity rotation rects (full copy, no rotation)
+    // Comma platform overrides these in InitPlatform() for device-specific rotation
+    CORE.Window.rotation_source = (Rectangle){ 0.0f, 0.0f, (float)CORE.Window.screen.width, -(float)CORE.Window.screen.height };
+    CORE.Window.rotation_destination = (Rectangle){ 0.0f, 0.0f, (float)CORE.Window.screen.width, (float)CORE.Window.screen.height };
+
     // Initialize global input state
     memset(&CORE.Input, 0, sizeof(CORE.Input));     // Reset CORE.Input structure to 0
     CORE.Input.Keyboard.exitKey = KEY_ESCAPE;
@@ -735,14 +740,6 @@ void InitWindow(int width, int height, const char *title)
     TRACELOG(LOG_INFO, "SYSTEM: Working Directory: %s", GetWorkingDirectory());
 
     CORE.Window.rotated_fb = LoadRenderTexture(CORE.Window.screen.width, CORE.Window.screen.height);
-
-    // Initialize default (identity) rotation params for non-comma platforms.
-    // rcore_comma.c's InitPlatform() sets rotation_destination.width > 0 for device rotation,
-    // so this guard prevents overwriting those values.
-    if (CORE.Window.rotation_destination.width == 0.0f) {
-        CORE.Window.rotation_source = (Rectangle){ 0.0f, 0.0f, (float)CORE.Window.screen.width, -(float)CORE.Window.screen.height };
-        CORE.Window.rotation_destination = (Rectangle){ 0.0f, 0.0f, (float)CORE.Window.screen.width, (float)CORE.Window.screen.height };
-    }
 
     CORE.Window.color_correction_shader = LoadShaderFromMemory(NULL, CORE.Window.color_correction_shader_src);
     if (!IsShaderValid(CORE.Window.color_correction_shader)) {

--- a/src/rcore.c
+++ b/src/rcore.c
@@ -770,10 +770,6 @@ void CloseWindow(void)
     ClosePlatform();
     //--------------------------------------------------------------
 
-    // Reset rotation state to prevent poisoning from temp windows
-    CORE.Window.rotation_source = (Rectangle){0};
-    CORE.Window.rotation_destination = (Rectangle){0};
-
     CORE.Window.ready = false;
     TRACELOG(LOG_INFO, "Window closed successfully");
 }


### PR DESCRIPTION
Fixes https://github.com/commaai/openpilot/issues/37533. Comma platform should still override these default rotations later, but for desktop rendering we need non-empty defaults, otherwise so the render texture is copied to an empty rect. I guess this change became necessary due to vendored raylib with offscreen support.

Opening against `platform-offscreen` instead of `master` since the former is the branch used by `commaai/dependencies`.
https://github.com/commaai/dependencies/blob/2e9aed768a3ec2bdc6d18313b86b422969460b61/raylib/build.sh#L66-L71

This is what I'm testing with in `pyproject.toml`:
`raylib @ git+https://github.com/TheSecurityDev/openpilot-dependencies.git@5c8119b047c7f911f264c34266c658d345ed993b#subdirectory=raylib`