### PR TITLE
comma: release GBM scanout buffers on close

### DIFF
--- a/src/platforms/rcore_comma.c
+++ b/src/platforms/rcore_comma.c
@@ -969,6 +969,9 @@ void SwapScreenBuffer(void) {
   }
 
   platform.gbm.current_bo = platform.gbm.next_bo;
+  platform.gbm.current_fb = platform.gbm.next_fb;
+  platform.gbm.next_bo = NULL;
+  platform.gbm.next_fb = 0;
 }
 
 //----------------------------------------------------------------------------------
@@ -1099,6 +1102,18 @@ void PollInputEvents(void) {
 //----------------------------------------------------------------------------------
 
 int InitPlatform(void) {
+  platform.drm.fd = -1;
+  platform.egl.display = EGL_NO_DISPLAY;
+  platform.egl.surface = EGL_NO_SURFACE;
+  platform.egl.context = EGL_NO_CONTEXT;
+  platform.gbm.device = NULL;
+  platform.gbm.surface = NULL;
+  platform.gbm.current_bo = NULL;
+  platform.gbm.next_bo = NULL;
+  platform.gbm.current_fb = 0;
+  platform.gbm.next_fb = 0;
+  platform.touch.fd = -1;
+
   // only support fullscreen
   CORE.Window.fullscreen = true;
   CORE.Window.flags |= FLAG_FULLSCREEN_MODE;
@@ -1169,8 +1184,21 @@ void ClosePlatform(void) {
     platform.egl.display = EGL_NO_DISPLAY;
   }
 
-  if (platform.gbm.surface && platform.gbm.next_bo) {
-    gbm_surface_release_buffer(platform.gbm.surface, platform.gbm.next_bo);
+  if (platform.gbm.surface) {
+    if (platform.gbm.next_bo) {
+      gbm_surface_release_buffer(platform.gbm.surface, platform.gbm.next_bo);
+      platform.gbm.next_bo = NULL;
+      platform.gbm.next_fb = 0;
+    }
+
+    if (platform.gbm.current_bo) {
+      gbm_surface_release_buffer(platform.gbm.surface, platform.gbm.current_bo);
+      platform.gbm.current_bo = NULL;
+      platform.gbm.current_fb = 0;
+    }
+
+    gbm_surface_destroy(platform.gbm.surface);
+    platform.gbm.surface = NULL;
   }
 
   if (platform.gbm.device) {
@@ -1178,5 +1206,13 @@ void ClosePlatform(void) {
     platform.gbm.device = NULL;
   }
 
-  close(platform.touch.fd);
+  if (platform.drm.fd >= 0) {
+    close(platform.drm.fd);
+    platform.drm.fd = -1;
+  }
+
+  if (platform.touch.fd >= 0) {
+    close(platform.touch.fd);
+    platform.touch.fd = -1;
+  }
 }


### PR DESCRIPTION
Fixes a COMMA platform teardown leak where UI process exits leave mdss-backed dma-bufs pinned. The close path now releases the active GBM BO, destroys the GBM surface before destroying the device, closes the DRM fd, and clears tracked BO/FB state after swaps.

Validated on tizi with a UI-only pyray probe: the mdss 9400320-byte dma-buf count stays flat across repeated gui_app.close() cycles with this patch; the old build leaked three such buffers per UI process restart.